### PR TITLE
hint user to check for swapped "name" and "path" properties when name…

### DIFF
--- a/src/create-matcher.js
+++ b/src/create-matcher.js
@@ -34,7 +34,7 @@ export function createMatcher (
     if (name) {
       const record = nameMap[name]
       if (process.env.NODE_ENV !== 'production') {
-        warn(record, `Route with name '${name}' does not exist`)
+        warn(record, `Route with name '${name}' does not exist. Did you unintentionally swap "name" and "path" properties?`)
       }
       if (!record) return _createRoute(null, location)
       const paramNames = record.regex.keys


### PR DESCRIPTION
…d route is not found

Got bitten by this simple mistake. Now, the log message hints the user to check for this mistake.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
